### PR TITLE
Add assertion to DialogBox and MainWindow class

### DIFF
--- a/src/main/java/venus/DialogBox.java
+++ b/src/main/java/venus/DialogBox.java
@@ -25,8 +25,15 @@ public class DialogBox extends HBox {
     @FXML
     private ImageView displayPicture;
 
+    /**
+     * Set up DialogBox, assert if the file is found.
+     *
+     * @param text Text to be wrapped for the DialogBox.
+     * @param img Image to be used for the DialogBox.
+     */
     private DialogBox(String text, Image img) {
         try {
+            assert MainWindow.class.getResource("/view/DialogBox.fxml") != null : "No FXML for DialogBox!";
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/DialogBox.fxml"));
             fxmlLoader.setController(this);
             fxmlLoader.setRoot(this);

--- a/src/main/java/venus/MainWindow.java
+++ b/src/main/java/venus/MainWindow.java
@@ -22,8 +22,21 @@ public class MainWindow extends AnchorPane {
 
     private Venus venus;
 
-    private Image userImage = new Image(this.getClass().getResourceAsStream("/images/user.png"));
-    private Image venusImage = new Image(this.getClass().getResourceAsStream("/images/bot.jpeg"));
+    private Image userImage; //= new Image(this.getClass().getResourceAsStream("/images/user.png"));
+    private Image venusImage; //= new Image(this.getClass().getResourceAsStream("/images/bot.jpeg"));
+
+    /**
+     * Constructor for main class that asserts user and bot images are there.
+     */
+    public MainWindow() {
+        super();
+        assert this.getClass().getResourceAsStream("/images/user.png") != null
+                : "User image not found!";
+        assert this.getClass().getResourceAsStream("/images/bot.jpeg") != null
+                : "User image not found!";
+        userImage = new Image(this.getClass().getResourceAsStream("/images/user.png"));
+        venusImage = new Image(this.getClass().getResourceAsStream("/images/bot.jpeg"));
+    }
 
     /**
      * Initialize program and adds welcome message.


### PR DESCRIPTION
We need assertion to check if resources are loaded correctly in our code.

Assertion present in code allows us to know if our code results in any error prematurely and with a convenient message to point to where the error is.

Let's add assert to the two new FXML bridging classes we add in Level 10 to check for important assertions in our code!

Other sources of exception are handled by earlier code.

To write better comments, visit oracle to find out more!